### PR TITLE
Prevent mint of 0 tokens in payTreasury()

### DIFF
--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -108,7 +108,9 @@ contract Treasury is TellorVars{
         if(votesSinceTreasury > 0){
             _mintAmount = _mintAmount *numVotesParticipated / votesSinceTreasury;
         }
-        IController(TELLOR_ADDRESS).mint(address(this),_mintAmount);
+        if (_mintAmount > 0) {
+            IController(TELLOR_ADDRESS).mint(address(this),_mintAmount);
+        }
         totalLocked -= treas.accounts[_investor].amount;
         IController(TELLOR_ADDRESS).transfer(_investor,_mintAmount + treas.accounts[_investor].amount);
         treasuryFundsByUser[_investor] -= treas.accounts[_investor].amount;

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -125,6 +125,10 @@ contract Treasury is TellorVars{
         );
     }
 
+    function getTreasuryCount() external view returns(uint256){
+        return treasuryCount;
+    }
+
     function getTreasuryDetails(uint256 _id) external view returns(uint256,uint256,uint256,uint256){
         return(treasury[_id].dateStarted,treasury[_id].totalAmount,treasury[_id].rate,treasury[_id].purchased);
     }

--- a/test/e2eTests2.js
+++ b/test/e2eTests2.js
@@ -15,72 +15,74 @@ describe("End-to-End Tests - Two", function() {
   const BIGWALLET = "0xf977814e90da44bfa03b6295a0616a897441acec";
   let accounts = null
   let tellor = null
-  let cfac,ofac,tfac,gfac,parachute
+  let cfac,ofac,tfac,gfac,parachute,govBig,govTeam
   let govSigner = null
-  let devWallet
   
-    beforeEach("deploy and setup TellorX", async function() {
-      accounts = await ethers.getSigners();
-      await hre.network.provider.request({
-        method: "hardhat_reset",
-        params: [{forking: {
-              jsonRpcUrl: hre.config.networks.hardhat.forking.url,
-              blockNumber:13004700
-            },},],
-        });
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [DEV_WALLET]}
-      )
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [PARACHUTE]}
-      )
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [BIGWALLET]}
-      )
-          //Steps to Deploy:
-          //Deploy Governance, Oracle, Treasury, and Controller. 
-          //Fork mainnet Ethereum, changeTellorContract to Controller
-          //run init in Controller
-  
-      oldTellorInstance = await ethers.getContractAt("contracts/tellor3/ITellor.sol:ITellor", tellorMaster)
-      gfac = await ethers.getContractFactory("contracts/testing/TestGovernance.sol:TestGovernance");
-      ofac = await ethers.getContractFactory("contracts/Oracle.sol:Oracle");
-      tfac = await ethers.getContractFactory("contracts/Treasury.sol:Treasury");
-      cfac = await ethers.getContractFactory("contracts/testing/TestController.sol:TestController");
-      governance = await gfac.deploy();
-      oracle = await ofac.deploy();
-      treasury = await tfac.deploy();
-      controller = await cfac.deploy();
-      await governance.deployed();
-      await oracle.deployed();
-      await treasury.deployed();
-      await controller.deployed();
-      await accounts[0].sendTransaction({to:DEV_WALLET,value:ethers.utils.parseEther("1.0")});
-      devWallet = await ethers.provider.getSigner(DEV_WALLET);
-      bigWallet = await ethers.provider.getSigner(BIGWALLET);
-      master = await oldTellorInstance.connect(devWallet)
-      await master.proposeFork(controller.address);
-      let _id = await master.getUintVar(h.hash("_DISPUTE_COUNT"))
-      await master.vote(_id,true)
-      master = await oldTellorInstance.connect(bigWallet)
-      await master.vote(_id,true);
-      await h.advanceTime(86400 * 8)
-      await master.tallyVotes(_id)
-      await h.advanceTime(86400 * 2.5)
-      await master.updateTellor(_id)
-      tellor = await ethers.getContractAt("contracts/interfaces/ITellor.sol:ITellor",tellorMaster, devWallet);
-      parachute = await ethers.getContractAt("contracts/interfaces/ITellor.sol:ITellor",PARACHUTE, devWallet);
-      await tellor.deployed();
-      await tellor.init(governance.address,oracle.address,treasury.address)
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [governance.address]}
-      )
-      await accounts[1].sendTransaction({to:governance.address,value:ethers.utils.parseEther("1.0")});
-      govSigner = await ethers.provider.getSigner(governance.address);
+  beforeEach("deploy and setup TellorX", async function() {
+    accounts = await ethers.getSigners();
+    await hre.network.provider.request({
+      method: "hardhat_reset",
+      params: [{forking: {
+            jsonRpcUrl: hre.config.networks.hardhat.forking.url,
+            blockNumber:13037866
+
+          },},],
+      });
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [DEV_WALLET]}
+    )
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [PARACHUTE]}
+    )
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [BIGWALLET]}
+    )
+        //Steps to Deploy:
+        //Deploy Governance, Oracle, Treasury, and Controller. 
+        //Fork mainnet Ethereum, changeTellorContract to Controller
+        //run init in Controller
+
+    oldTellorInstance = await ethers.getContractAt("contracts/tellor3/ITellor.sol:ITellor", tellorMaster)
+    gfac = await ethers.getContractFactory("contracts/testing/TestGovernance.sol:TestGovernance");
+    ofac = await ethers.getContractFactory("contracts/Oracle.sol:Oracle");
+    tfac = await ethers.getContractFactory("contracts/Treasury.sol:Treasury");
+    cfac = await ethers.getContractFactory("contracts/testing/TestController.sol:TestController");
+    governance = await gfac.deploy();
+    oracle = await ofac.deploy();
+    treasury = await tfac.deploy();
+    controller = await cfac.deploy();
+    await governance.deployed();
+    await oracle.deployed();
+    await treasury.deployed();
+    await controller.deployed();
+    await accounts[0].sendTransaction({to:DEV_WALLET,value:ethers.utils.parseEther("1.0")});
+    devWallet = await ethers.provider.getSigner(DEV_WALLET);
+    bigWallet = await ethers.provider.getSigner(BIGWALLET);
+    master = await oldTellorInstance.connect(devWallet)
+    await master.proposeFork(controller.address);
+    let _id = await master.getUintVar(h.hash("_DISPUTE_COUNT"))
+    await master.vote(_id,true)
+    master = await oldTellorInstance.connect(bigWallet)
+    await master.vote(_id,true);
+    await h.advanceTime(86400 * 8)
+    await master.tallyVotes(_id)
+    await h.advanceTime(86400 * 2.5)
+    await master.updateTellor(_id)
+    tellor = await ethers.getContractAt("contracts/interfaces/ITellor.sol:ITellor",tellorMaster, devWallet);
+    parachute = await ethers.getContractAt("contracts/interfaces/ITellor.sol:ITellor",PARACHUTE, devWallet);
+    govTeam = await ethers.getContractAt("contracts/interfaces/ITellor.sol:ITellor",governance.address, devWallet);
+    govBig = await ethers.getContractAt("contracts/interfaces/ITellor.sol:ITellor",governance.address, bigWallet);
+    await tellor.deployed();
+    await tellor.init(governance.address,oracle.address,treasury.address)
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [governance.address]}
+    )
+    await accounts[1].sendTransaction({to:governance.address,value:ethers.utils.parseEther("1.0")});
+    govSigner = await ethers.provider.getSigner(governance.address);
     });
   it("What happens if a staked miner is disputed twice? (maybe have window for disputes to prevent this?)", async function() {
     
@@ -219,12 +221,62 @@ describe("End-to-End Tests - Two", function() {
 
     it("No votes during treasury duration", async function() {
 
-      //create treasury buyer
+      let treasuryAmount = BigInt(500E18)
+      let treasuryRate
+      let treasuryDuration = 3600 * 24 * 14 //14 days
 
-      //issue treasuries
+      let n = 42
+      let requestId = keccak256("0x"+n.toString(16))
+      let disputedValue = keccak256("0x"+n.toString(16))
 
-      //user buys treasury
+      //create treasury buyer, reporter, disputer
+      let [buyer, reporter, disputer] = await ethers.getSigners()
 
-      //
+      //mint tokens for buyer
+      await tellor.connect(devWallet).transfer(buyer.address, BigInt(101E18))
+      console.log(1)
+      //mint and stake reporter
+      await tellor.connect(devWallet).transfer(reporter.address, BigInt(101E18))
+      console.log(2)
+      //mint and stake disputer
+      await tellor.connect(devWallet).transfer(disputer.address, BigInt(200E18))
+      console.log(3)
+      //governance issues treasuries
+      await treasury.connect(govSigner).issueTreasury(treasuryAmount, treasuryRate, treasuryDuration)
+      let treasuryCount = treasury.getTreasuryCount()
+console.log(4)
+      //buyer buys treasury
+      await treasury.connect(buyer).buyTreasury(treasuryCount)
+console.log(5)
+      //reporter submits a value
+      await tellor.connect(reporter).submitValue(requestId, disputedValue)
+      let currentBlock = await ethers.provider.getBlock()
+      let timestamp = currentBlock.timestamp
+console.log(6)
+      //disputer disputes value
+      await tellor.connect(disputer).beginDispute(requestId, timestamp)
+      let voteCount = await governance.voteCount()
+
+
+      //user doesn't vote
+      await h.advanceTime(86400 * 7) //7 days
+
+      //tally vote      
+      await tellor.tallyVotes(voteCount)
+      await h.advanceTime(86400*7) //7 days
+
+      //execute vote
+      await tellor.executeVote(voteCount)
+
+      //fast forward to treasury expiration
+      await h.advanceTime(86400)
+
+      //pay treasury
+      let oldBalance = await tellor.balanceOf(buyer.address)
+      await treasury.connect(buyer).payTreasury(buyer.address, treasuryCount)
+      let newBalance = await tellor.balanceOf(buyer.address)
+      //penalty on invalid vote?
+      expect(oldBalance).to.equal(newBalance)
+
     })
 });


### PR DESCRIPTION
In Treasury.sol, if a treasury buyer doesn't vote at all, they should receive no treasury rewards. However, the ERC20 standard reverts mint amounts of 0, considering it "non-positive". I added an if-block to only mint treasury rewards if the mint amount is > 0.

I opted not to edit the Token.sol file. Editing the ERC20 logic seemed more risky than editing higher level contract logic. Open to discussion, though.