### PR TITLE
Edit for future governance upgrades

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -717,10 +717,13 @@ contract Governance is TellorVars {
      */
     function isApprovedGovernanceContract(address _contract)
         external
-        view
         returns (bool)
     {
-        return true;
+        if (_contract == IController(TELLOR_ADDRESS).addresses(_GOVERNANCE_CONTRACT)) {
+          return true;
+        } else {
+          return false;
+        }
     }
 
     /**

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -712,6 +712,18 @@ contract Governance is TellorVars {
     }
 
     /**
+     * @dev Used for future governance contract upgrades. Hardcode old contract address in next upgrade
+     * @param _contract is the contract address to check
+     */
+    function isApprovedGovernanceContract(address _contract)
+        external
+        view
+        returns (bool)
+    {
+        return true;
+    }
+
+    /**
      * @dev Returns whether or not a function is approved
      * @param _func is the hash of the function to be checked
      * @return bool of whether or not the function is approved

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -719,10 +719,13 @@ contract Governance is TellorVars {
         external
         returns (bool)
     {
-        if (_contract == IController(TELLOR_ADDRESS).addresses(_GOVERNANCE_CONTRACT)) {
-          return true;
+        if (
+            _contract ==
+            IController(TELLOR_ADDRESS).addresses(_GOVERNANCE_CONTRACT)
+        ) {
+            return true;
         } else {
-          return false;
+            return false;
         }
     }
 

--- a/contracts/TellorStaking.sol
+++ b/contracts/TellorStaking.sol
@@ -25,7 +25,12 @@ contract TellorStaking is Token {
      * @param _status is the new status of the reporter
      */
     function changeStakingStatus(address _reporter, uint256 _status) external {
-        require(msg.sender == addresses[_GOVERNANCE_CONTRACT]);
+        // require(msg.sender == addresses[_GOVERNANCE_CONTRACT]);
+        require(
+            IGovernance(addresses[_GOVERNANCE_CONTRACT])
+                .isApprovedGovernanceContract(msg.sender),
+            "Only approved governance contract can change staking status"
+        );
         StakeInfo storage stakes = stakerDetails[_reporter];
         stakes.currentStatus = _status;
     }
@@ -80,7 +85,12 @@ contract TellorStaking is Token {
      * @param _disputer is the address of the disputer receiving the reporter's stake
      */
     function slashReporter(address _reporter, address _disputer) external {
-        require(msg.sender == addresses[_GOVERNANCE_CONTRACT]);
+        // require(msg.sender == addresses[_GOVERNANCE_CONTRACT]);
+        require(
+            IGovernance(addresses[_GOVERNANCE_CONTRACT])
+                .isApprovedGovernanceContract(msg.sender),
+            "Only approved governance contract can slash reporter"
+        );
         stakerDetails[_reporter].currentStatus = 5; // Change status of reporter to slashed
         // Transfer stake amount of reporter has a balance bigger than the stake amount
         if (balanceOf(_reporter) >= uints[_STAKE_AMOUNT]) {

--- a/contracts/TellorStaking.sol
+++ b/contracts/TellorStaking.sol
@@ -25,7 +25,6 @@ contract TellorStaking is Token {
      * @param _status is the new status of the reporter
      */
     function changeStakingStatus(address _reporter, uint256 _status) external {
-        // require(msg.sender == addresses[_GOVERNANCE_CONTRACT]);
         require(
             IGovernance(addresses[_GOVERNANCE_CONTRACT])
                 .isApprovedGovernanceContract(msg.sender),
@@ -85,7 +84,6 @@ contract TellorStaking is Token {
      * @param _disputer is the address of the disputer receiving the reporter's stake
      */
     function slashReporter(address _reporter, address _disputer) external {
-        // require(msg.sender == addresses[_GOVERNANCE_CONTRACT]);
         require(
             IGovernance(addresses[_GOVERNANCE_CONTRACT])
                 .isApprovedGovernanceContract(msg.sender),

--- a/contracts/interfaces/IGovernance.sol
+++ b/contracts/interfaces/IGovernance.sol
@@ -16,6 +16,7 @@ interface IGovernance{
     function vote(uint256 _id, bool _supports, bool _invalidQuery) external;
     function voteFor(address[] calldata _addys,uint256 _id, bool _supports, bool _invalidQuery) external;
     function getDelegateInfo(address _holder) external view returns(address,uint);
+    function isApprovedGovernanceContract(address _contract) external view returns(bool);
     function isFunctionApproved(bytes4 _func) external view returns(bool);
     function getVoteCount() external view returns(uint256);
     function getVoteRounds(bytes32 _hash) external view returns(uint256[] memory);


### PR DESCRIPTION
- add isApprovedGovernanceContract getter to governance contract.  ̶A̶l̶w̶a̶y̶s̶ ̶r̶e̶t̶u̶r̶n̶s̶ ̶`̶t̶r̶u̶e̶`̶ ̶i̶n̶ ̶t̶h̶i̶s̶ ̶c̶o̶n̶t̶r̶a̶c̶t̶. If we upgrade governance in the future, we should change this function to something like:

```
function isApprovedGovernanceContract(address _contract) external view returns (bool) {
        if (_contract == IController(TELLOR_ADDRESS).addresses(_GOVERNANCE_CONTRACT) || _contract == 0xOLD_GOV_ADDRESS) {
              return true;
        else {
              return false;
        }
}
```

This will deal with active disputes during a governance contract upgrade.